### PR TITLE
Tokenizer trust remote code

### DIFF
--- a/src/xllm/core/dependencies.py
+++ b/src/xllm/core/dependencies.py
@@ -241,7 +241,9 @@ def build_tokenizer(config: Config, use_fast: Optional[bool] = None) -> PreTrain
         kwargs["use_fast"] = use_fast
 
     tokenizer = AutoTokenizer.from_pretrained(
-        pretrained_model_name_or_path=config.correct_tokenizer_name_or_path, **kwargs
+        pretrained_model_name_or_path=config.correct_tokenizer_name_or_path,
+        trust_remote_code=config.trust_remote_code,
+        **kwargs,
     )
 
     if tokenizer.pad_token is None:


### PR DESCRIPTION
## Description

When loading the tokenizer, there could have been issues, for example with the 01-ai/Yi-6B and 01-ai/Yi-34B models, as they have their own tokenizer. This is resolved by adding trust_remote_code to the tokenizer load.

<!-- Add a more detailed description of the changes if needed. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
