### PR TITLE
Feature: Allow for overriding pad_token_id

### DIFF
--- a/src/xllm/core/config.py
+++ b/src/xllm/core/config.py
@@ -430,6 +430,12 @@ class Config:
             "help": "Padding side of the collator: None, right or left",
         },
     )
+    tokenizer_padding_token: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Padding token for tokenizer",
+        },
+    )
 
     # collator
     collator_key: str = field(

--- a/src/xllm/core/dependencies.py
+++ b/src/xllm/core/dependencies.py
@@ -246,6 +246,12 @@ def build_tokenizer(config: Config, use_fast: Optional[bool] = None) -> PreTrain
         **kwargs,
     )
 
+    if config.tokenizer_padding_token is not None:
+        tokenizer.pad_token = config.tokenizer_padding_token
+        dist_logger.info(
+            f"Overrode tokenizer pad token with {config.tokenizer_padding_token}", local_rank=config.local_rank
+        )
+
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
         dist_logger.info(message="Tokenizer pad token set to eos token", local_rank=config.local_rank)


### PR DESCRIPTION
## Description

Currently, the library selects `eos` when no pad token is defined in the tokenizer. This negatively impacts finetuning some Llama models such as Mistral-Instruct since it uses `eos` to end it's answer in a chat setting. I believe this is because when `eos` is a pad token, it'll be ignored (attention mask to 0) and the model might forget using `eos` as training progresses.

To fix this, we can now override the pad token with anything we wish.  In my case, I have something like this:

```python
config = Config(model_name_or_path="mistralai/Mistral-7B-Instruct-v0.2",
                tokenizer_padding_token="<unk>", # << Note this change
                apply_lora=True,
                lora_rank=2,
                neftune_noise_alpha=0.1,
                load_in_4bit=True,
                per_device_train_batch_size=2,
                gradient_accumulation_steps=4,
                prepare_model_for_kbit_training=True,
                llm_int8_threshold=6.0,
                llm_int8_has_fp16_weight=True,
                bnb_4bit_use_double_quant=True,
                bnb_4bit_quant_type="nf4",
                use_gradient_checkpointing=True,
                use_flash_attention_2=True)
```

This does not update the tokenizer of the final model, and I noticed positive results during inference compared to training without it. I hope this PR finds you well and thank you for such an awesome library, it's now my daily driver!

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
